### PR TITLE
タグ絞込み時にページングが機能していなかったのを修正

### DIFF
--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -10,9 +10,9 @@ class PostController < ApplicationController
   end
 
   def list_by_tag
-    tag_id = params['i'] ? params['i'].to_i : 1
+    @tag_id = params['i'] ? params['i'].to_i : 1
 
-    tag = Tag.find( tag_id )
+    tag = Tag.find( @tag_id )
 
     @count = tag.contents.count
     @contents = tag.contents

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -66,7 +66,7 @@ module PostHelper
     if( tag_id.nil? )
       html += "<li class='#{ page == 1 ? 'disabled' : '' }'>#{ link_to '&laquo;'.html_safe, root_path( p:1 ) }</li>"
     else
-      html += "<li class='#{ page == 1 ? 'disabled' : '' }'>#{ link_to '&laquo;'.html_safe, post_list_by_tag_path( p:1, t:tag_id ) }</li>"
+      html += "<li class='#{ page == 1 ? 'disabled' : '' }'>#{ link_to '&laquo;'.html_safe, post_list_by_tag_path( p:1, i:tag_id ) }</li>"
     end
 
     # 1 ~ 最終ページへのリンク
@@ -74,7 +74,7 @@ module PostHelper
       if( tag_id.nil? )
         html += "<li class='#{ page == i ? 'active' : '' }'>#{ link_to i, root_path( p:i ) }</li>"
       else
-        html += "<li class='#{ page == i ? 'active' : '' }'>#{ link_to i, post_list_by_tag_path( p:i, t:tag_id ) }</li>"
+        html += "<li class='#{ page == i ? 'active' : '' }'>#{ link_to i, post_list_by_tag_path( p:i, i:tag_id ) }</li>"
       end
     end
 
@@ -82,7 +82,7 @@ module PostHelper
     if( tag_id.nil? )
       html += "<li class='#{ page == i ? 'disabled' : '' }'>#{ link_to '&raquo;'.html_safe, root_path( p:1 ) }</li>"
     else
-      html += "<li class='#{ page == i ? 'disabled' : '' }'>#{ link_to '&raquo;'.html_safe, post_list_by_tag_path( p:1, t:tag_id ) }</li>"
+      html += "<li class='#{ page == i ? 'disabled' : '' }'>#{ link_to '&raquo;'.html_safe, post_list_by_tag_path( p:1, i:tag_id ) }</li>"
     end
 
     html += "</ul>"


### PR DESCRIPTION
#18 

ページングで遷移すると、絞込みが解除された通常のリストになってしまっていた。

---

### テスト

![image](https://cloud.githubusercontent.com/assets/11205591/19917317/6be7e812-a105-11e6-8968-e1fe38b903cf.png)
