### PR TITLE
スマホデザイン修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -22,7 +22,8 @@ footer {
   .footer-category {
     float: left;
     margin-left: 32px;
-    width: 320px;
+    width: 80%;
+    max-width: 320px;
 
     .title {
       margin-bottom: 12px;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -162,3 +162,15 @@ div.list-group-item {
 .fb-comments, .fb-comments span, .fb-comments iframe {
   width: 100% !important;
 }
+
+@media screen and (max-width: 450px) {
+  .pc {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 451px) {
+  .sp {
+    display: none;
+  }
+}

--- a/app/views/layouts/_content.html.erb
+++ b/app/views/layouts/_content.html.erb
@@ -7,10 +7,8 @@
  <h4 class="title"><%= title %></h4>
   <ul class="list-group">
     <% contents.each do | content | %>
-      <%= link_to( post_search_path( i: content['id'] ) ) do %>
-        <li class="list-group-item">
-          <%= content['title'] %>
-        </li>
+      <%= link_to( post_search_path( i: content['id'] ), { :class => 'list-group-item' } ) do %>
+        <%= content['title'] %>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -7,10 +7,8 @@
         <h4 class="title">カテゴリ</h4>
         <ul class="list-group">
           <% @recommend_tags.each do | tag | %>
-            <%= link_to( post_list_by_tag_path( i: tag['id'] ) ) do %>
-              <li class="list-group-item">
+            <%= link_to( post_list_by_tag_path( i: tag['id'] ), { :class => 'list-group-item' } ) do %>
               <%= tag['name'] %>
-              </li>
             <% end %>
           <% end %>
         </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,7 +9,10 @@
       </button>
       <%= link_to( root_path, :class => "navbar-brand" ) do %>
         <div class="title-icon"></div>
-        <div class="title-text"><%= t( 'title' ) %></div>
+        <div class="title-text">
+          <p class='pc'><%= t( 'title' ) %></p>
+          <p class='sp'><%= t( 'title-short' ) %></p>
+        </div>
       <% end %>
     </div>
 


### PR DESCRIPTION
### 関連

#22 

### レビュアー

@


### 概要

スマホサイトデザイン崩れの修正

### 変更点

内容 | 変更前 | 変更後
--- | --- | ---
ヘッダータイトル崩れ | ![2017-06-29 18 50 44](https://user-images.githubusercontent.com/11205591/27681992-efa42b68-5cfb-11e7-9bc6-98b8c554a1e5.png) | ![2017-06-30 18 56 21](https://user-images.githubusercontent.com/11205591/27731003-50af30b8-5dc6-11e7-814f-debdca103210.png)
フッターリストの崩れ | ![2017-06-30 19 02 22](https://user-images.githubusercontent.com/11205591/27731095-ab673bfe-5dc6-11e7-9997-63508244d965.png) | ![2017-06-30 18 59 07](https://user-images.githubusercontent.com/11205591/27731005-524a2590-5dc6-11e7-8ddb-2912293e2940.png)


### テスト結果


### 保留した点やTODO


### その他


